### PR TITLE
Use steady clock instead of system clock

### DIFF
--- a/lib/Common/TimeDifference.cpp
+++ b/lib/Common/TimeDifference.cpp
@@ -16,7 +16,7 @@
 #include "rtosim/EndOfData.h"
 #include "rtosim/QueuesSync.h"
 #include <chrono>
-using std::chrono::system_clock;
+using std::chrono::steady_clock;
 using std::chrono::duration_cast;
 #include <algorithm>
 #include <numeric>
@@ -196,14 +196,14 @@ namespace rtosim {
     template<typename Q>
     void TimeProbe<Q>::initialise() {
 
-        t_initialTimePoint_ = system_clock::now();
+        t_initialTimePoint_ = steady_clock::now();
         c_initialTimePoint_ = std::clock();
     }
 
     template<typename Q>
     void TimeProbe<Q>::logCurrentTime(double frameTime) {
 
-        system_clock::time_point t_newTimePoint(system_clock::now());
+        steady_clock::time_point t_newTimePoint(steady_clock::now());
         std::clock_t c_newTimePoint(std::clock());
 
         //using system clock

--- a/lib/Common/rtosim/TimeDifference.h
+++ b/lib/Common/rtosim/TimeDifference.h
@@ -87,7 +87,7 @@ namespace rtosim {
         void logCurrentTime(double frameTime);
         Q& queue_;
         
-        std::chrono::system_clock::time_point t_initialTimePoint_;
+        std::chrono::steady_clock::time_point t_initialTimePoint_;
         TimeData<double> t_frameProcessingTimes_;
 
         std::clock_t c_initialTimePoint_;

--- a/lib/OutputDevice/StateVisualiser.cpp
+++ b/lib/OutputDevice/StateVisualiser.cpp
@@ -51,7 +51,7 @@ namespace rtosim{
         viz.setDesiredFrameRate(60);
         ShowInfo* info = new ShowInfo();
         viz.addDecorationGenerator(info);
-        auto start = std::chrono::system_clock::now();
+        auto start = std::chrono::steady_clock::now();
         int frameCounter = 0;
         bool localRunCondition(true);
         while (localRunCondition) {
@@ -69,9 +69,9 @@ namespace rtosim{
             viz.report(s);
             frameCounter++;
 
-            if ((std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - start)) > std::chrono::milliseconds(1000)) {
+            if ((std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start)) > std::chrono::milliseconds(1000)) {
                 info->setText("IK FPS: " + std::to_string(frameCounter));
-                start = std::chrono::system_clock::now();
+                start = std::chrono::steady_clock::now();
                 frameCounter = 0;
             }
         }

--- a/lib/Utilities/StopWatch.cpp
+++ b/lib/Utilities/StopWatch.cpp
@@ -17,7 +17,7 @@
 #include "rtosim/FileSystem.h"
 
 #include <chrono>
-using std::chrono::system_clock;
+using std::chrono::steady_clock;
 using std::chrono::duration_cast;
 #include <algorithm>
 #include <fstream>
@@ -40,13 +40,13 @@ namespace rtosim {
 
     void StopWatch::init() {
         id_ = std::this_thread::get_id();
-        t_initialTimePoint_ = t_finalTimePoint_ = t_timePoint_ = system_clock::now();
+        t_initialTimePoint_ = t_finalTimePoint_ = t_timePoint_ = steady_clock::now();
         c_initialTimePoint_ = c_finalTimePoint_ = c_timePoint_ = std::clock();
     }
 
     void StopWatch::log() {
 
-        system_clock::time_point t_newTimePoint(system_clock::now());
+        steady_clock::time_point t_newTimePoint(steady_clock::now());
         std::clock_t c_newTimePoint(std::clock());
 
         //using system clock
@@ -154,7 +154,7 @@ namespace rtosim {
 
     StopWatch& StopWatch::operator+=(const StopWatch& rhs)
     {
-        t_initialTimePoint_ = t_finalTimePoint_ = t_timePoint_ = system_clock::now();
+        t_initialTimePoint_ = t_finalTimePoint_ = t_timePoint_ = steady_clock::now();
         this->t_frameProcessingTime_.insert(this->t_frameProcessingTime_.end(), rhs.t_frameProcessingTime_.begin(), rhs.t_frameProcessingTime_.end());
 
         c_initialTimePoint_ = c_finalTimePoint_ = c_timePoint_ = std::clock();

--- a/lib/Utilities/rtosim/StopWatch.h
+++ b/lib/Utilities/rtosim/StopWatch.h
@@ -68,7 +68,7 @@ namespace rtosim {
 
     private:
         Double getMedian(const std::list<Double>& v) const; //move it as free function
-        std::chrono::system_clock::time_point t_timePoint_, t_initialTimePoint_, t_finalTimePoint_;
+        std::chrono::steady_clock::time_point t_timePoint_, t_initialTimePoint_, t_finalTimePoint_;
         std::list<Double> t_frameProcessingTime_;
 
         std::clock_t c_timePoint_, c_initialTimePoint_, c_finalTimePoint_;


### PR DESCRIPTION
Steady clock avoids possible issues in calculating time differences if system clock resets.
http://en.cppreference.com/w/cpp/chrono/steady_clock