### PR TITLE
fix std::sqrt for Linux

### DIFF
--- a/lib/Utilities/rtosim/StopWatch.h
+++ b/lib/Utilities/rtosim/StopWatch.h
@@ -22,6 +22,7 @@
 #include <ctime>
 #include <numeric>
 #include <algorithm>
+#include <cmath>
 
 namespace rtosim {
 


### PR DESCRIPTION
std::sqrt require inclusion of cmath on Linux.